### PR TITLE
Added expressjs-style routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "less-plugin-clean-css": "^1.5.1",
     "node-postgres-named": "^2.4.1",
     "partial.lenses": "^10.0.1",
+    "path-to-regexp": "^1.7.0",
     "pg": "^6.1.5",
     "pg-native": "^1.10.1",
     "postcss-cli": "^3.1.1",

--- a/src/public/components/header.js
+++ b/src/public/components/header.js
@@ -12,6 +12,7 @@ export default ({visible = U.atom(true)}) =>
         <Link href="/">Main</Link>
         <Link href="/another-page">Another page</Link>
         <Link href="/form">Form</Link>
+        <Link href="/main/1234">Main with ID</Link>
       </div>
     </div>
   </div>

--- a/src/public/components/page.js
+++ b/src/public/components/page.js
@@ -1,11 +1,11 @@
-import React from "karet"
+import React      from "karet"
 
-import NotFound from "../pages/not-found"
+import NotFound   from "../pages/not-found"
 
-import routes from "../routes"
+import routes     from "../routes"
 
-import Header from "./header"
-import Router from "./router"
+import Header     from "./header"
+import { Router } from "./router"
 
 export default () =>
   <div>

--- a/src/public/components/router.js
+++ b/src/public/components/router.js
@@ -52,14 +52,14 @@ const prepareParams =
 
 const resolveDynamic = path =>
   R.compose( R.reduce( ( acc, { component, regex } ) =>
-                       R.ifElse( R.isNil
-                               , R.always( acc )
-                               , match =>
-                                   R.reduced( { component
-                                              , params: prepareParams( regex.keys )( R.tail( match ) )
-                                              }
-                                            )
-                               )( regex.exec( path ) )
+                         R.ifElse( R.isNil
+                                 , R.always( acc )
+                                 , match =>
+                                     R.reduced( { component
+                                                , props: prepareParams( regex.keys )( R.tail( match ) )
+                                                }
+                                              )
+                                 )( regex.exec( path ) )
                      , false
                      )
            , L.get( 'dynamic' )
@@ -67,11 +67,11 @@ const resolveDynamic = path =>
 
 const resolveRoute = ( { routes, NotFound }, { path }  ) =>
   U.fromKefir( K( path, path =>
-                  { const { component, params } =
+                  { const { component, props } =
                       resolveStatic( path )( routes )
                       || resolveDynamic( path )( routes )
                       || { component: NotFound, path }
-                    return React.createElement( component, params )
+                    return React.createElement( component, props )
                   }
                 )
              )

--- a/src/public/components/router.js
+++ b/src/public/components/router.js
@@ -1,6 +1,83 @@
-import K, * as U from "karet.util"
-import React     from "karet"
+import * as R     from "ramda"
+import * as L     from "partial.lenses"
+import K, * as U  from "karet.util"
+import React      from "karet"
+import toRegex    from 'path-to-regexp'
 
-export default U.withContext(({routes, NotFound}, {path}) => U.fromKefir(K(path, path =>
-  React.createElement(routes[path] || NotFound)
-)))
+const W = a => b => a( b )( b )
+
+// TODO: Make it possible to add routes more than once?
+
+// begin routes initialization
+const partitionDynamicAndStatic =
+  R.partition( R.compose( R.lt( 0 )
+                        , R.length
+                        , L.get( [ 'regex', 'keys' ] )
+                        )
+             )
+
+const addRegexes =
+  R.map( W( R.compose( L.set( 'regex' )
+                     , toRegex
+                     , L.get( 'route' )
+                     )
+          )
+       )
+
+const expandRoutes =
+  R.compose( R.map( R.zipObj( [ 'route', 'component' ] ) )
+           , R.toPairs
+           )
+
+const init =
+  R.compose( R.zipObj( [ 'dynamic', 'static' ] )
+           , partitionDynamicAndStatic
+           , addRegexes
+           , expandRoutes
+           )
+// end routes initialization
+
+//
+
+// begin route resolution
+const resolveStatic = path =>
+  R.compose( R.find( R.propEq( 'route', path ) )
+           , L.get( 'static' )
+           )
+
+const prepParams =
+  R.compose( R.zipObj
+           , R.map( L.get( 'name' ) )
+           )
+
+const resolveDynamic = path =>
+  R.compose( R.reduce( ( acc, { component, route, regex } ) =>
+                       { const match = regex.exec( path )
+                         return match !== null
+                                ? R.reduced( { component, path, route, regex
+                                             , params: prepParams( regex.keys )( R.tail( match ) )
+                                             }
+                                           )
+                                : acc
+                       }
+                     , false
+                     )
+           , L.get( 'dynamic' )
+           )
+
+const resolveRoute = ( { routes, NotFound }, { path }  ) =>
+  U.fromKefir( K( path, path =>
+                  { const { component, ...route } =
+                      resolveStatic( path )( routes )
+                      || resolveDynamic( path )( routes )
+                      || { component: NotFound, path }
+                    return React.createElement( component, route )
+                  }
+                )
+             )
+// end route resolution
+
+const Router = U.withContext( resolveRoute )
+Router.init = init
+
+export default Router

--- a/src/public/components/router.js
+++ b/src/public/components/router.js
@@ -70,7 +70,7 @@ const resolveRoute = ( { routes, NotFound }, { path }  ) =>
                   { const { component, props } =
                       resolveStatic( path )( routes )
                       || resolveDynamic( path )( routes )
-                      || { component: NotFound, path }
+                      || { component: NotFound }
                     return React.createElement( component, props )
                   }
                 )

--- a/src/public/components/router.js
+++ b/src/public/components/router.js
@@ -6,6 +6,7 @@ import toRegex    from 'path-to-regexp'
 
 // TODO: Make it possible to add routes more than once?
 
+// begin routes initialization
 const expandRoutes = rawRoutes =>
   R.pipe( R.toPairs
         , R.map( R.zipObj( [ 'route', 'component' ] ) )
@@ -18,7 +19,6 @@ const addRegexes = expandedRoutes =>
                         )( route )( route )
        )( expandedRoutes )
 
-// begin routes initialization
 const partitionDynamicAndStatic = routesWithRegexes =>
   R.partition( R.pipe( L.get( [ 'regex', 'keys' ] )
                      , R.length

--- a/src/public/pages/main.js
+++ b/src/public/pages/main.js
@@ -26,12 +26,10 @@ const Contacts = ({contacts}) =>
     Number of contacts: {U.length(contacts)}
   </div>
 
-export default U.withContext((props, {state}) =>
+export default U.withContext(({ id }, {state}) =>
   <div>
     <h1>Main page</h1>
     <Contacts contacts={U.view(["contacts", L.define([])], state)}/>
-    { typeof L.get( [ 'params', 'id' ], props ) !== 'undefined'
-      && <div>With ID: { L.get( [ 'params', 'id' ], props ) }</div>
-    }
+    { U.ift( id, <div>With ID: { id }</div> ) }
   </div>
 )

--- a/src/public/pages/main.js
+++ b/src/public/pages/main.js
@@ -26,8 +26,12 @@ const Contacts = ({contacts}) =>
     Number of contacts: {U.length(contacts)}
   </div>
 
-export default U.withContext((_, {state}) =>
+export default U.withContext((props, {state}) =>
   <div>
     <h1>Main page</h1>
     <Contacts contacts={U.view(["contacts", L.define([])], state)}/>
-  </div>)
+    { typeof L.get( [ 'params', 'id' ], props ) !== 'undefined'
+      && <div>With ID: { L.get( [ 'params', 'id' ], props ) }</div>
+    }
+  </div>
+)

--- a/src/public/routes.js
+++ b/src/public/routes.js
@@ -1,9 +1,13 @@
+import Router      from "./components/router"
 import Main        from "./pages/main"
 import AnotherPage from "./pages/another-page"
 import Form        from "./pages/form/page"
 
-export default {
-  "/": Main,
-  "/another-page": AnotherPage,
-  "/form": Form
+const routes = {
+  '/': Main,
+  '/main/:id': Main,
+  '/another-page': AnotherPage,
+  '/form': Form
 }
+
+export default Router.init( routes )

--- a/src/public/routes.js
+++ b/src/public/routes.js
@@ -1,7 +1,7 @@
-import Router      from "./components/router"
-import Main        from "./pages/main"
-import AnotherPage from "./pages/another-page"
-import Form        from "./pages/form/page"
+import { prepareRoutes } from "./components/router"
+import Main              from "./pages/main"
+import AnotherPage       from "./pages/another-page"
+import Form              from "./pages/form/page"
 
 const routes = {
   '/': Main,
@@ -10,4 +10,4 @@ const routes = {
   '/form': Form
 }
 
-export default Router.init( routes )
+export default prepareRoutes( routes )


### PR DESCRIPTION
Most changes are in router.js.
I npm installed path-to-regexp, used by the expressjs router.
I updated routes.js to work with the new router and added a route with
a path param.
I updated header.js and main.js to show an example of a route with a
path param working (/main/:id -> /main/1234)