### PR TITLE
Refined sort fn and fixed keys problem

### DIFF
--- a/src/public/components/router.js
+++ b/src/public/components/router.js
@@ -13,7 +13,10 @@ const expandRoutes =
 
 const addRegexes =
   R.map( entry =>
-         ( { ...entry, regex: toRegex( entry.route ) } )
+         { const regex = toRegex( entry.route )
+           regex.keys = regex.keys.map( R.prop( 'name' ) )
+           return { ...entry, regex }
+         }
        )
 
 const sortStaticFirst =
@@ -32,7 +35,7 @@ const router = U.lift( ( { routes, NotFound }, { path } ) =>
          const { Component, regex } = routes[ i ]
          const match = regex.exec( path )
          if ( match )
-           return <Component { ...R.zipObj( regex.keys.map( R.prop( 'name' ) ), R.tail( match ) ) }/>
+           return <Component { ...R.zipObj( regex.keys, R.tail( match ) ) }/>
        }
        return <NotFound/>
      }

--- a/src/public/components/router.js
+++ b/src/public/components/router.js
@@ -16,13 +16,13 @@ const addRegexes =
          ( { ...entry, regex: toRegex( entry.route ) } )
        )
 
-const sortByStaticThenDynamic =
-  R.sortBy( ( { regex } ) => regex.keys.length )
+const sortStaticFirst =
+  R.sortBy( ( { regex } ) => regex.keys.length === 0 ? 0 : 1 )
 
 export const prepareRoutes =
   R.pipe( expandRoutes
         , addRegexes
-        , sortByStaticThenDynamic
+        , sortStaticFirst
         )
 // end routes initialization
 
@@ -32,7 +32,7 @@ const router = U.lift( ( { routes, NotFound }, { path } ) =>
          const { Component, regex } = routes[ i ]
          const match = regex.exec( path )
          if ( match )
-           return <Component { ...R.zipObj( regex.keys, R.tail( match ) ) }/>
+           return <Component { ...R.zipObj( regex.keys.map( R.prop( 'name' ) ), R.tail( match ) ) }/>
        }
        return <NotFound/>
      }


### PR DESCRIPTION
My post-refactoring testing was obviously not thorough enough. Here I've refined the sort function that puts static routes ahead of dynamic routes and fixed a problem with `regex.keys` that was causing the `props` sent to the `Component` to look like `'{ [Object object]': 'value' }`.

Apologies for the poor testing!